### PR TITLE
Clean migration-era TODO markers and add banned-TODO lint

### DIFF
--- a/crates/dev-algorithm-comparison/ablation/run.rs
+++ b/crates/dev-algorithm-comparison/ablation/run.rs
@@ -37,7 +37,6 @@ use std::io::{BufWriter, Write};
 use std::time::Instant;
 use symplectic::geom::polygon::{random_polygon_2d, regular_polygon_2d};
 use symplectic::random::generate_random_polytopes;
-// TODO: These will be re-exported from top-level `symplectic::` in wave 4 (subagent #16).
 use symplectic::algorithms::hk2017::{ehz_capacity_unpruned, EhzResult};
 use symplectic::geom::known_polytopes;
 use symplectic::geom::lagrangian_product::lagrangian_product;

--- a/crates/dev-algorithm-comparison/benchmark/run.rs
+++ b/crates/dev-algorithm-comparison/benchmark/run.rs
@@ -12,7 +12,6 @@
 //!
 //! Total: ~85 polytopes, ~100 capacity computations
 
-// TODO: These will be re-exported from top-level `symplectic::` in wave 4 (subagent #16).
 use symplectic::algorithms::billiard::billiard_capacity;
 use symplectic::random::generate_random_polytopes;
 use symplectic::geom::lagrangian_product::lagrangian_product;

--- a/crates/dev-capacity-validation/correctness/run.rs
+++ b/crates/dev-capacity-validation/correctness/run.rs
@@ -29,7 +29,6 @@
 //!
 //! Total: 47 pruned + 10 unpruned + 14 billiard = 71 capacity values
 
-// TODO: These will be re-exported from top-level `symplectic::` in wave 4 (subagent #16).
 use symplectic::algorithms::billiard::billiard_capacity;
 use symplectic::random::generate_random_polytopes;
 use symplectic::geom::known_polytopes::{

--- a/crates/dev-numerical-analysis/kkt-inertia/run.rs
+++ b/crates/dev-numerical-analysis/kkt-inertia/run.rs
@@ -17,21 +17,15 @@
 /// Input: Known polytopes from the library (F ≤ 10).
 /// Output: Summary tables to stdout. No hard assertions (diagnostic experiment).
 use nalgebra::{DMatrix, DVector, Vector4};
-// TODO: `combinations` moved to `algorithms::hk2017::permutations::combinations` (wave 3, subagent #6)
-// TODO: `cyclic_permutations` stays at `algorithms::hk2017::permutations::cyclic_permutations` (wave 3, subagent #6)
-// TODO: `build_kkt_system` renamed to `kkt::qp_assembly::build_augmented_system` with signature
-//   change: now takes (polytope, perm) instead of (normals, heights, perm).
-//   `q_from_beta` removed from public API; replaced by `kkt::q_value(h, beta)` which takes
-//   the pre-assembled H matrix instead of (normals, perm, beta).
-//   For now, these experiments keep local copies with the old (normals, heights, perm) signatures
-//   since the experiment logic extracts normals/heights for direct manipulation.
-// TODO: `cyclic_permutations` stays at `algorithms::hk2017::permutations::cyclic_permutations`
-//   once wave 3 (subagent #6) writes permutations.rs.
+// TODO: Missing experiment wiring to library permutation/KKT helpers; implement by replacing local
+// TODO: `cyclic_permutations`, `combinations`, and `build_kkt` with public APIs in
+// TODO: crates/library/src/algorithms/hk2017/mod.rs and crates/library/src/kkt/qp_assembly.rs;
+// TODO: acceptance: this file compiles without local copies of those helpers.
 use symplectic::geom::known_polytopes;
 use symplectic::geom::polytope::Polytope4D;
 use symplectic::geom::symplectic_form::omega0;
 
-// ── Local copies of library functions (modules not yet written in migration) ──
+// ── Local copies of library functions kept for experiment compatibility ──
 
 /// Generate all cyclic permutations (fix first element, permute rest).
 /// Previously imported from `symplectic::algorithms::hk2017::permutations::cyclic_permutations`.

--- a/crates/dev-numerical-analysis/q-error/run.rs
+++ b/crates/dev-numerical-analysis/q-error/run.rs
@@ -12,21 +12,17 @@
 //! Input: Known polytopes from the library (F ≤ 10).
 //! Output: Summary tables to stdout. Panics on any violation.
 use nalgebra::{DMatrix, DVector, Vector4};
-// TODO: `ehz_capacity` and `combinations` move to `algorithms::hk2017` (wave 3, subagent #6)
-// TODO: `cyclic_permutations` stays at `algorithms::hk2017::permutations::cyclic_permutations` (wave 3)
-// TODO: `build_kkt_system` renamed to `kkt::qp_assembly::build_augmented_system` with signature
-//   change: now takes (polytope, perm) instead of (normals, heights, perm).
-//   `q_from_beta` removed from public API.
-// TODO: `kkt_rational` renamed to `kkt::rational_solver` (wave 2, subagent #3)
-// TODO: ehz_capacity will be re-exported from algorithms::hk2017 once wave 3 (subagent #6) writes hk2017/mod.rs
+// TODO: Missing experiment wiring to library permutation/KKT helpers; implement by replacing local
+// TODO: `cyclic_permutations`, `combinations`, and `build_kkt` with public APIs in
+// TODO: crates/library/src/algorithms/hk2017/mod.rs and crates/library/src/kkt/qp_assembly.rs;
+// TODO: acceptance: this file compiles without local copies of those helpers.
 use symplectic::algorithms::hk2017::ehz_capacity;
-// TODO: cyclic_permutations will be available from hk2017::permutations once wave 3 (subagent #6) writes it
 use symplectic::geom::known_polytopes;
 use symplectic::geom::polytope::Polytope4D;
 use symplectic::geom::symplectic_form::omega0;
 use symplectic::kkt::rational_solver as kkt_rational;
 
-// ── Local copies of library functions (modules not yet written in migration) ──
+// ── Local copies of library functions kept for experiment compatibility ──
 
 /// Generate all cyclic permutations (fix first element, permute rest).
 /// Previously imported from `symplectic::algorithms::hk2017::permutations::cyclic_permutations`.

--- a/crates/dev-numerical-analysis/unknown-predicates/run.rs
+++ b/crates/dev-numerical-analysis/unknown-predicates/run.rs
@@ -18,7 +18,6 @@ use std::io::{BufWriter, Write};
 use std::time::Instant;
 use symplectic::geom::polygon::{regular_polygon_2d, rotate_polygon_2d};
 use symplectic::random::generate_random_polytopes;
-// TODO: These will be re-exported from top-level `symplectic::` in wave 4 (subagent #16).
 use symplectic::algorithms::billiard::billiard_capacity;
 use symplectic::algorithms::hk2017::ehz_capacity;
 use symplectic::geom::lagrangian_product::lagrangian_product;

--- a/crates/exp-sys-landscape/rotated-regular-products/run.rs
+++ b/crates/exp-sys-landscape/rotated-regular-products/run.rs
@@ -8,7 +8,6 @@
 //!    rotated-regular-products/lagrangian-products-<n>x<m>-6deg.jsonl
 //!
 //! Capacity algorithm: billiard (fast, production default for Lagrangian products).
-// TODO: These will be re-exported from top-level `symplectic::` in wave 4 (subagent #16).
 use symplectic::algorithms::billiard::billiard_capacity;
 use symplectic::geom::lagrangian_product::lagrangian_product;
 use symplectic::geom::polygon::{polygon_area, regular_polygon_2d, rotate_polygon_2d};

--- a/crates/library/src/algorithms/hk2017/mod.rs
+++ b/crates/library/src/algorithms/hk2017/mod.rs
@@ -1643,9 +1643,9 @@ mod tests_capacity_derivative {
     /// which may introduce O(eps) systematic error for FD. The old code used
     /// `volume_divergence` (divergence theorem from H-rep) for cleaner FD.
     ///
-    /// TODO: If FD volume tests show excessive error, add a volume_divergence function
-    /// to the volume module (dropped during migration). The divergence theorem computes
-    /// vol = (1/4) sum h_i * vol_3D(F_i) directly from H-representation.
+    /// TODO: Missing H-representation volume derivative backend for finite-difference validation;
+    /// implement `volume_divergence` in crates/library/src/geom/volume.rs;
+    /// acceptance: this module's Euler finite-difference test no longer needs qhull volume.
     fn fd_volume_derivatives(normals: &[Vector4<f64>], heights: &[f64]) -> Vec<f64> {
         let f = heights.len();
         (0..f)
@@ -1729,13 +1729,14 @@ mod tests_capacity_derivative {
     ///
     /// Polytopes: simplex, hypercube. Tolerance: 0.1% relative.
     ///
-    /// TODO: This test uses qhull-based volume. The old code used `volume_divergence`
-    /// (divergence theorem from H-rep) which gives clean FD with O(eps^2) truncation error.
+    /// TODO: Missing H-representation finite-difference volume path in
+    /// crates/library/src/geom/volume.rs (`volume_divergence`);
+    /// acceptance: replace qhull-based FD here and remove `#[ignore]` from this test.
     /// Qhull computes volume from V-rep triangulation, which introduces O(eps) systematic
     /// error in FD because the triangulation topology can change with small perturbations.
     /// If this test fails on hypercube, restore `volume_divergence` in geom/volume.rs.
     #[test]
-    #[ignore] // Requires volume_divergence (dropped during migration) for clean FD
+    #[ignore] // Requires `volume_divergence` implementation in geom/volume.rs for clean FD
     fn euler_homogeneity_volume() {
         let polytopes: Vec<(&str, Polytope4D)> = vec![
             ("simplex", known_polytopes::simplex().polytope.clone()),

--- a/scripts/check-banned-todo-phrases.sh
+++ b/scripts/check-banned-todo-phrases.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Check for migration-era TODO wording that should not re-enter code comments.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+shopt -s nullglob
+TARGETS=(crates/dev-* crates/exp-* crates/library/src)
+shopt -u nullglob
+
+# Banned only when attached to TODO comments.
+PATTERN='TODO:.*(subagent #[0-9]+|\bwave [0-9]+\b|re-exported from top-level `symplectic::`|modules not yet written in migration|dropped during migration)'
+
+echo "Checking for banned TODO phrases..."
+if rg -n --pcre2 -e "$PATTERN" "${TARGETS[@]}" --glob '*.rs' --glob '*.tex'; then
+  echo
+  echo "Found banned TODO phrase(s). Rewrite as:"
+  echo "  TODO: Missing <what>; implement in <path/symbol>; acceptance: <condition>."
+  exit 1
+fi
+
+echo "No banned TODO phrases found."


### PR DESCRIPTION
### Motivation
- Remove migration-era markers (`subagent #...`, `wave N`, migration phrasing) and session identity from code comments so source files only contain actionable developer TODOs and no session history.  
- Normalize TODOs to a single format that states what is missing, where to implement it, and the acceptance condition to make migration tasks actionable.  
- Prevent reintroduction of banned phrasing by adding an automated check that runs across experiments and library source.  

### Description
- Removed obsolete migration-era TODO lines from experiment binaries where the imports already reflect the current API (examples: `crates/dev-capacity-validation/correctness/run.rs`, `crates/dev-algorithm-comparison/ablation/run.rs`, `crates/dev-algorithm-comparison/benchmark/run.rs`, `crates/dev-numerical-analysis/unknown-predicates/run.rs`, `crates/exp-sys-landscape/rotated-regular-products/run.rs`).  
- Replaced migration-era TODO blocks in `crates/dev-numerical-analysis/q-error/run.rs` and `crates/dev-numerical-analysis/kkt-inertia/run.rs` with normalized actionable TODOs that name the target modules (`crates/library/src/algorithms/hk2017/mod.rs` and `crates/library/src/kkt/qp_assembly.rs`) and an explicit acceptance condition (`this file compiles without local copies of those helpers`).  
- Normalized and clarified TODOs in `crates/library/src/algorithms/hk2017/mod.rs` to describe the missing `volume_divergence` backend, where to implement it, and the acceptance criterion for the Euler finite-difference test.  
- Adjusted local-copy headers to state the reason for keeping local helpers in experiments and avoid migration-era wording, and added a new lint script `scripts/check-banned-todo-phrases.sh` that searches for banned TODO phrases and fails if they are found.  

### Testing
- Ran `scripts/check-banned-todo-phrases.sh` (no banned TODO phrases found).  
- Ran ripgrep checks `rg -n "subagent #[0-9]+|\bwave [0-9]+\b"` and `rg -n "TODO:"` across the updated targets as spot-checks (returned no banned phrases in the targeted paths).  
- All automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd78adaa88832b919dab6c3b9dcf2d)